### PR TITLE
Fix typo in README config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Here's an example of how it could be configured:
       {
         "key": "sk-4dy7adya89dyh3sca68a78yauwsdhjf",
         "url": "https://api.openai.com",
-        "models": [gpt-3-5-turbo, gpt-3.5-turbo-0301, gpt-3.5-turbo-16k]
+        "models": [gpt-3.5-turbo, gpt-3.5-turbo-0301, gpt-3.5-turbo-16k]
       },
       {
         "key": "tr-dwadaw78xcawoidja0'w9dia9dwf",


### PR DESCRIPTION
## Summary
- correct the model name in the README configuration example

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f48957b8c83229481fb755294f975